### PR TITLE
change "description-file" to "description_file" in response to python warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@
 universal=1
 
 [metadata]
-description-file = README.md
+description_file = README.md
 


### PR DESCRIPTION
Problem arose after last merge (in Azure):

```
Starting: Build source dist
==============================================================================
Task         : Command line
Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
Version      : 2.212.0
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
==============================================================================
Generating script.
Script contents:
python setup.py  sdist --dist-dir "/Users/runner/work/1/s/dist"
========================== Starting Command Output ===========================
/bin/bash --noprofile --norc /Users/runner/work/_temp/26c52ed7-60c8-4671-89af-891157b6275e.sh
/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/dist.py:770: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
Traceback (most recent call last):
  File "/Users/runner/work/1/s/setup.py", line 28, in <module>
    setup(
  File "/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
  File "/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 147, in setup
    _setup_distribution = dist = klass(attrs)
  File "/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/dist.py", line 475, in __init__
    _Distribution.__init__(
  File "/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 258, in __init__
    getattr(self.metadata, "set_" + key)(val)
  File "/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 1242, in set_classifiers
    self.classifiers = _ensure_list(value, 'classifiers')
  File "/Users/runner/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 48, in _ensure_list
    log.warning(msg)
AttributeError: module 'distutils.log' has no attribute 'warning'
##[error]Bash exited with code '1'.
Finishing: Build source dist
```